### PR TITLE
Fix edit() issue

### DIFF
--- a/lib/aka.rb
+++ b/lib/aka.rb
@@ -152,47 +152,48 @@ module Aka
       else
         puts "TODO: this should simply call the usual function"
         puts "no group is used"
-        if args
-          values = args.split("=")
-          if values.size > 1
-            truth, _alias = Aka.search_alias_return_alias_tokens(args)
-            if truth == true
-              if options.name
-                Aka.remove(_alias) #remove that alias
-                Aka.edit_alias_name(values[1], _alias) #edit that alias
-                Aka.reload_dot_file if !options.noreload
-              else
-                Aka.remove(_alias) #remove that alias
-                Aka.edit_alias_command(values[1], _alias) #edit that alias
-                Aka.reload_dot_file if !options.noreload
-              end
+      end # end else no group option
+
+      if args
+        values = args.split("=")
+        if values.size > 1
+          truth, _alias = Aka.search_alias_return_alias_tokens(args)
+          if truth == true
+            if options.name
+              Aka.remove(_alias) #remove that alias
+              Aka.edit_alias_name(values[1], _alias) #edit that alias
+              Aka.reload_dot_file if !options.noreload
             else
-              Aka.error_statement("Alias '#{args}' cannot be found.")
+              Aka.remove(_alias) #remove that alias
+              Aka.edit_alias_command(values[1], _alias) #edit that alias
+              Aka.reload_dot_file if !options.noreload
             end
           else
-            truth, _alias, command = Aka.search_alias_return_alias_tokens(args)
-            if truth == true
-              if options.name
-                input = ask "Enter a new alias for command '#{command}'?\n"
-                if yes? "Please confirm the new alias? (y/N)"
-                  Aka.remove(_alias) #remove that alias
-                  Aka.edit_alias_name(input, command) #edit that alias
-                  Aka.reload_dot_file if !options.noreload
-                end
-              else
-                input = ask "Enter a new command for alias '#{args}'?\n"
-                if yes? "Please confirm the new command? (y/N)"
-                  Aka.remove(_alias) #remove that alias
-                  Aka.edit_alias_command(input, _alias) #edit that alias
-                  Aka.reload_dot_file if !options.noreload
-                end
+            Aka.error_statement("Alias '#{args}' cannot be found.")
+          end
+        else
+          truth, _alias, command, group = Aka.search_alias_return_alias_tokens_with_group(args)
+          if truth == true
+            if options.name
+              input = ask "Enter a new alias for command '#{command}'?\n"
+              if yes? "Please confirm the new alias? (y/N)"
+                Aka.remove(_alias) #remove that alias
+                Aka.edit_alias_name_with_group(input, command, group) #edit that alias
+                Aka.reload_dot_file if !options.noreload
               end
             else
-              Aka.error_statement("Alias '#{args}' cannot be found")
+              input = ask "Enter a new command for alias '#{args}'?\n"
+              if yes? "Please confirm the new command? (y/N)"
+                Aka.remove(_alias) #remove that alias
+                Aka.edit_alias_command_with_group(input, _alias, group) #edit that alias
+                Aka.reload_dot_file if !options.noreload
+              end
             end
+          else
+            Aka.error_statement("Alias '#{args}' cannot be found")
           end
-        end #if args
-      end # end else no group option
+        end
+      end #if args
     end
 
     #

--- a/lib/aka.rb
+++ b/lib/aka.rb
@@ -26,7 +26,7 @@ module Aka
     #################
     desc :proj, "list the project alias (short alias: p)"
     method_option :group, :type => :boolean, :aliases => '-g'
-    method_option :load, :type => :string, :aliases => '-i' 
+    method_option :load, :type => :string, :aliases => '-i'
     method_option :save, :type => :string, :aliases => '-e'
     method_option :force, :type => :boolean, :aliases => '-f'
 
@@ -141,56 +141,58 @@ module Aka
       if options.group
           if options.group != 'default'
             puts "Editing for the following alias - "
-            answer = ask "do you want to change the group from xxxx to #{options.group}?"
-            Aka.change_group_name_with(options.group) if yes?
+            # answer = ask "Do you want to change the group from xxxx to #{options.group}?"
+            # Aka.change_alias_group_name_with(Aka.parseARGS(args),options.group) if yes?
+            if yes? "Do you want to change the group from xxxx to #{options.group}?"
+              Aka.change_alias_group_name_with(Aka.parseARGS(args),options.group)
+            end
           else
             puts "TODO: The user did not enter a new alias group"
           end
       else
         puts "TODO: this should simply call the usual function"
         puts "no group is used"
-      end
-
-      if args
-        values = args.split("=")
-        if values.size > 1
-          truth, _alias = Aka.search_alias_return_alias_tokens(args)
-          if truth == true
-            if options.name
-              Aka.remove(_alias) #remove that alias
-              Aka.edit_alias_name(values[1], _alias) #edit that alias
-              Aka.reload_dot_file if !options.noreload
-            else
-              Aka.remove(_alias) #remove that alias
-              Aka.edit_alias_command(values[1], _alias) #edit that alias
-              Aka.reload_dot_file if !options.noreload
-            end
-          else
-            Aka.error_statement("Alias '#{args}' cannot be found.")
-          end
-        else
-          truth, _alias, command = Aka.search_alias_return_alias_tokens(args)
-          if truth == true
-            if options.name
-              input = ask "Enter a new alias for command '#{command}'?\n"
-              if yes? "Please confirm the new alias? (y/N)"
+        if args
+          values = args.split("=")
+          if values.size > 1
+            truth, _alias = Aka.search_alias_return_alias_tokens(args)
+            if truth == true
+              if options.name
                 Aka.remove(_alias) #remove that alias
-                Aka.edit_alias_name(input, command) #edit that alias
+                Aka.edit_alias_name(values[1], _alias) #edit that alias
+                Aka.reload_dot_file if !options.noreload
+              else
+                Aka.remove(_alias) #remove that alias
+                Aka.edit_alias_command(values[1], _alias) #edit that alias
                 Aka.reload_dot_file if !options.noreload
               end
             else
-              input = ask "Enter a new command for alias '#{args}'?\n"
-              if yes? "Please confirm the new command? (y/N)"
-                Aka.remove(_alias) #remove that alias
-                Aka.edit_alias_command(input, _alias) #edit that alias
-                Aka.reload_dot_file if !options.noreload
-              end
+              Aka.error_statement("Alias '#{args}' cannot be found.")
             end
           else
-            Aka.error_statement("Alias '#{args}' cannot be found")
+            truth, _alias, command = Aka.search_alias_return_alias_tokens(args)
+            if truth == true
+              if options.name
+                input = ask "Enter a new alias for command '#{command}'?\n"
+                if yes? "Please confirm the new alias? (y/N)"
+                  Aka.remove(_alias) #remove that alias
+                  Aka.edit_alias_name(input, command) #edit that alias
+                  Aka.reload_dot_file if !options.noreload
+                end
+              else
+                input = ask "Enter a new command for alias '#{args}'?\n"
+                if yes? "Please confirm the new command? (y/N)"
+                  Aka.remove(_alias) #remove that alias
+                  Aka.edit_alias_command(input, _alias) #edit that alias
+                  Aka.reload_dot_file if !options.noreload
+                end
+              end
+            else
+              Aka.error_statement("Alias '#{args}' cannot be found")
+            end
           end
-        end
-      end #if args
+        end #if args
+      end # end else no group option
     end
 
     #

--- a/lib/aka/helpers.rb
+++ b/lib/aka/helpers.rb
@@ -240,6 +240,34 @@ def self.search_alias_with_group_name name
   end
 end
 
+#change alias group name
+def self.change_alias_group_name_with input, new_group_name
+  str = is_config_file_present?(readYML("#{CONFIG_PATH}")["dotfile"])
+  if content = File.open(str).read
+    content.gsub!(/\r\n?/, "\n")
+    content_array = content.split("\n")
+
+    content_array.each_with_index { |line, index|
+      value = line.split(" ")
+      if value.length > 1 && value.first == "alias"
+        aliasWithoutGroup = line.split("# =>").first.strip
+        answer = value[1].split("=") #contains the alias
+        if input == answer.first
+          alias_n_command = aliasWithoutGroup.split(" ").drop(1).join(" ")
+          containsCommand = alias_n_command.split('=') #containsCommand[1]
+          containsCommand[1].slice!(0) && containsCommand[1].slice!(containsCommand[1].length-1) if containsCommand[1] != nil && containsCommand[1][0] == "'" && containsCommand[1][containsCommand[1].length-1] == "'"
+          alias_n_command = answer.first+"="+containsCommand[1]
+          remove(answer.first)
+          result = add_with_group(alias_n_command,new_group_name)
+          reload_dot_file if result
+        end
+      end
+    }
+  else
+    puts "#{@pwd} cannot be found.".red
+  end
+end
+
 def self.export_group_aliases name
   str = is_config_file_present?(readYML("#{CONFIG_PATH}")["dotfile"])
   results = []


### PR DESCRIPTION
Isuue 1: Cannot edit alias group

Create change_alias_group_name_with helper
It change alias's group
eg
aka edit test -g=newgroup

Issue 2: When edit() alias, the group is not inherit to new alias.

Create search_alias_return_alias_tokens_with_group helper
return [true, this_alias, containsCommand[1], group_name]
it return extra info - group_name

Create edit_alias_command_with_group helper, 
compare to edit_alias_command
this new helper received group_name and append in the new alias

Create edit_alias_name_with_group helper
compare to edit_alias_name
this new helper received group_name and append in the new alias
